### PR TITLE
Add pixel-char cycling as an option

### DIFF
--- a/example.py
+++ b/example.py
@@ -9,7 +9,9 @@ quantized_coco = image_coco.get_colour_quantize_image(components=20, seed=None)
 print(image_manip.quantized_to_ascii_str(quantized_coco))
 print(image_manip.quantized_to_pixelart_str(quantized_coco))
 image_manip.quantized_to_ascii_html(quantized_coco, "coco_ascii.html")
-image_manip.quantized_to_pixelart_html(quantized_coco, "coco_pixelart.html")
+image_manip.quantized_to_pixelart_html(
+    quantized_coco, "coco_pixelart.html", pixel_chars="coco! ", pixel_format="cycle"
+)
 image_manip.quantized_to_pixelart_html(
     quantized_coco, "coco_big_pixelart.html", font_size=24
 )
@@ -26,6 +28,8 @@ print(image_manip.quantized_to_ascii_str(quantized_fringes))
 
 image_screenshot = image_manip.ImageManipulate("screenshot.png")
 image_screenshot.resize(800, None)
-quantized_screenshot = image_screenshot.get_colour_quantize_image(components=20, seed=None)
+quantized_screenshot = image_screenshot.get_colour_quantize_image(
+    components=20, seed=None
+)
 
 image_manip.quantized_to_cartoon_file(quantized_screenshot, "filtered_ss.png")


### PR DESCRIPTION
Clean up addition of allow pixel characters. It is now just an option of the previous pixelart functions (rather than a separate function altogether).
Removed the monospace font styling, we only need the line-height specification to prevent stretching.
